### PR TITLE
Updated to be Django 2.0 through 4.0 compatible

### DIFF
--- a/froala_editor/urls.py
+++ b/froala_editor/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.urls import re_path
 from froala_editor import views
 
 urlpatterns = [
-    url(r'^image_upload/$', views.image_upload, name='froala_editor_image_upload'),
-    url(r'^file_upload/$', views.file_upload, name='froala_editor_file_upload'),
+    re_path(r'^image_upload/$', views.image_upload, name='froala_editor_image_upload'),
+    re_path(r'^file_upload/$', views.file_upload, name='froala_editor_file_upload'),
 ]


### PR DESCRIPTION
The urls.py file was still using the pre Django 2.0 url function rather than re_path. re_path became the new standard in 2.0 and the old url() method will be removed in Django 4.0 so it may as well be removed now to allow this package to keep working